### PR TITLE
[Add]SearchFunction

### DIFF
--- a/app/assets/javascripts/searches.coffee
+++ b/app/assets/javascripts/searches.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/searches.scss
+++ b/app/assets/stylesheets/searches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the searches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,11 @@
+class SearchesController < ApplicationController
+  def search
+    @search_word = params["search_word"]
+    @records = search_for(@search_word)
+  end
+  
+  private
+  def search_for(search_word)
+    Product.where(name: search_word)
+  end
+end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -1,0 +1,2 @@
+module SearchesHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,7 @@
             </ul>
           </div>
         </div>
+        <%= render 'searches/search' %>
       </nav>
     </header>
     <%= yield %>

--- a/app/views/searches/_search.html.erb
+++ b/app/views/searches/_search.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag(search_path, :method => 'get') do %>
+  <%= text_field_tag 'search_word' %>
+  <%= submit_tag '検索' %>
+<% end %>

--- a/app/views/searches/search_view.html.erb
+++ b/app/views/searches/search_view.html.erb
@@ -1,0 +1,6 @@
+<h2>search for "<%= @search_word %>"</h2><br>
+<% if admin_signed_in? %>
+  <%= render 'admin/products/index' , products: @records %>
+<% else %>
+  <%= render 'customer/products/index' , products: @records %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
     sessions: "admin/sessions"
   }
+  
+  #商品検索フォーム用
+  get 'search' , to:'searches#search'
 
   #customer側↓
 

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SearchesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#検索機能の追加
・ヘッダーに検索フォームを作成
・部分一致で検索ができるような仕様
・検索後は管理者でログインしていれば管理者用の商品一覧画面へ、それ以外はエンドユーザー側の商品一覧画面の検索結果を表示するようにしている。
現在は部分テンプレートとして飛ばしているので、検索するとエラー吐きます。
後ほど管理者側product/indexとエンドユーザー側product/indexを部分テンプレート化したいです。

もしくは一度同じ記述を再度書いてpushします。