### PR TITLE
Authenticate admin

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,4 +1,6 @@
 class Admin::CustomersController < ApplicationController
+  before_action :authenticate_admin!
+  
   def index
     @customers = Customer.page(params[:page])
   end

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,4 +1,5 @@
 class Admin::GenresController < ApplicationController
+  before_action :authenticate_admin!
   def index
     @genre = Genre.new
     @genres = Genre.all

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GenresController < ApplicationController
   before_action :authenticate_admin!
+  
   def index
     @genre = Genre.new
     @genres = Genre.all

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,4 +1,5 @@
 class Admin::HomesController < ApplicationController
+  before_action :authenticate_admin!
   def top
     @orders = Order.page(params[:page]).per(10).reverse_order
     #customer/showから偏移した場合は、:id keyを受け取ってcustomerの注文履歴だけを表示する

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,5 +1,6 @@
 class Admin::HomesController < ApplicationController
   before_action :authenticate_admin!
+  
   def top
     @orders = Order.page(params[:page]).per(10).reverse_order
     #customer/showから偏移した場合は、:id keyを受け取ってcustomerの注文履歴だけを表示する

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,4 +1,5 @@
 class Admin::OrdersController < ApplicationController
+  before_action :authenticate_admin!
 
   def show
     @order = Order.find(params[:id])

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,4 +1,5 @@
 class Admin::ProductsController < ApplicationController
+  before_action :authenticate_admin!
 
   def index
     @products = Product.page(params[:page]).per(10)


### PR DESCRIPTION
★管理者ページへのログイン制限を入れました　-ログインしていないと管理者ログインに戻されます
・ユーザー情報/ジャンル/注文履歴/商品　ページへのログイン制御