### PR TITLE
カート画面リンク修正

### DIFF
--- a/app/assets/stylesheets/customer/products.scss
+++ b/app/assets/stylesheets/customer/products.scss
@@ -2,6 +2,3 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.product-show {
-  display: flex;
-}

--- a/app/views/customer/cart_products/index.html.erb
+++ b/app/views/customer/cart_products/index.html.erb
@@ -35,7 +35,7 @@
 
   <div class="row justify-content-end  mt-5">
     <div class="col-lg-3 mt-3">
-      <%= link_to "買い物を続ける", products_path, class:"btn btn-sm btn-primary" %>
+      <%= link_to "買い物を続ける", root_path, class:"btn btn-sm btn-primary" %>
     </div>
 
       <table class="col table-bordered offset-7">

--- a/app/views/customer/products/show.html.erb
+++ b/app/views/customer/products/show.html.erb
@@ -7,28 +7,27 @@
       <%= render 'customer/products/genre_search_form', genres: @genres %>
     </div>
 
-    <!-- 商品画像・名前・説明 -->
-    <div class="col-md-9 product-show">
-      <div class="col-md-6">
+    <!-- 商品画像 -->
+    <div class="col-md-3">
         <%= attachment_image_tag @product, :image, format: 'jpeg', fallback: "no_image.jpg", size: "300x200" %>
+    </div>
+    
+    <!-- 商品説明・個数 -->
+    <div class="col-md-4 offset-1">
+      <h2><%= @product.name %></h2><br>
+      <p><%= @product.explanation %></p>
+      <div>
+        <h3>￥<%=(@product.price * 1.1).floor %><font size="3">（税込）</font></h3>
       </div>
-      <div class="col-md-6">
-        <h2><%= @product.name %></h2><br>
-        <p><%= @product.explanation %></p>
-        <div>
-          <h3>￥<%=(@product.price * 1.1).floor %><font size="3">（税込）</font></h3>
-        </div>
-
-        <!-- 個数選択・決定ボタン（非ログイン時は隠れます）-->
-        <% if customer_signed_in? %>
+      <!-- 個数選択・決定ボタン（非ログイン時は隠れます）-->
+      <% if customer_signed_in? %>
           <%= form_with model: @cart_product,local:true do |f| %>
             <%= f.select :quantity, [*(1..10)], {include_blank: '個数選択'} %>
             <%= f.hidden_field :customer_id, :value => current_customer.id %>
             <%= f.hidden_field :product_id, :value => @product.id %>
               <%= f.submit "カートに入れる", class:"ml-5 mt-4 btn btn-success" %>
           <% end %>
-        <% end %>
-      </div>
+      <% end %>
     </div>
 
   </div>

--- a/app/views/customer/products/show.html.erb
+++ b/app/views/customer/products/show.html.erb
@@ -8,12 +8,12 @@
     </div>
 
     <!-- 商品画像 -->
-    <div class="col-md-3">
+    <div class="col-md-4">
         <%= attachment_image_tag @product, :image, format: 'jpeg', fallback: "no_image.jpg", size: "300x200" %>
     </div>
-    
+
     <!-- 商品説明・個数 -->
-    <div class="col-md-4 offset-1">
+    <div class="col-md-5">
       <h2><%= @product.name %></h2><br>
       <p><%= @product.explanation %></p>
       <div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <header>
       <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
-          <a class="navbar-brand" href="/">LOGO</a>
+          <a class="navbar-brand" href="/">HOME</a>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>


### PR DESCRIPTION
カート画面の「買い物を続ける」ボタンのリンクを、
ホーム画面に変更しました。

他、下記内容変更
・商品詳細画面のブートストラップ修正
・ヘッダーの「LOGO」を一応「HOME」に変更しておきました。