### PR TITLE
会員新規登録後の遷移先修正

### DIFF
--- a/app/controllers/customer/registrations_controller.rb
+++ b/app/controllers/customer/registrations_controller.rb
@@ -40,6 +40,10 @@ class Customer::RegistrationsController < Devise::RegistrationsController
 
   # protected
 
+  def after_sign_up_path_for(_resource)
+    customers_my_page_path
+  end
+
   def after_update_path_for(resource)
     customers_my_page_path
   end


### PR DESCRIPTION
会員側で新規会員登録した際に、マイページではなくトップページに
遷移していたので修正しました。