### PR TITLE
トップ画面のブートストラップ修正

### DIFF
--- a/app/controllers/customer/registrations_controller.rb
+++ b/app/controllers/customer/registrations_controller.rb
@@ -40,6 +40,10 @@ class Customer::RegistrationsController < Devise::RegistrationsController
 
   # protected
 
+  def after_sign_up_path_for(_resource)
+    customers_my_page_path
+  end
+
   def after_update_path_for(resource)
     customers_my_page_path
   end

--- a/app/views/customer/homes/top.html.erb
+++ b/app/views/customer/homes/top.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <!-- メイン部分 -->
-    <div class="col-md-8">
+    <div class="col-md-9">
       <div class="toptitle mb-4">
         <h1>Welcom to NaganoCake !</h1>
       </div>
@@ -30,13 +30,11 @@
 
       <!-- 新着商品を4件表示 -->
       <% @product.each do |product| %>
-        <div class="mt-3" style="float: right;">
-          <div class="col-md-12">
-            <div class="card">
-              <%= attachment_image_tag product, :image, format: 'jpeg', fallback: "no_image.jpg", height:150 %>
-              <p class= "mt-3"><%= link_to product.name, product_path(product.id) %></p>
-              <p>￥<%= product.price %></p>
-            </div>
+        <div class="col-md-3 mt-3" style="float: right;">
+          <div class="card">
+            <%= attachment_image_tag product, :image, format: 'jpeg', fallback: "no_image.jpg", height:150 %>
+            <p class= "mt-3"><%= link_to product.name, product_path(product.id) %></p>
+            <p>￥<%= product.price %></p>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
トップ画面の新着商品４件を表示する記述で、ブートストラップの記述に誤りが
有りましたので修正しました。
・商品の画像幅によって、レイアウトが崩れてしまう点を修正

会員側で新規会員登録した際に、マイページではなくトップページに
遷移していたので修正しました。