### PR TITLE
フッターを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -89,4 +89,18 @@ td > a{
 }
 #logo{
   font-family: Hannotate SC;
-} 
+}
+
+.wrapper{
+  margin-bottom: -70px;
+}
+
+footer{
+  margin-top: 30px;
+  height: 70px;
+  text-align: center;
+}
+
+.push {
+  height: 70px;/*フッターと同じ高さに指定*/
+}

--- a/app/controllers/customer/registrations_controller.rb
+++ b/app/controllers/customer/registrations_controller.rb
@@ -40,6 +40,10 @@ class Customer::RegistrationsController < Devise::RegistrationsController
 
   # protected
 
+  def after_sign_up_path_for(_resource)
+    customers_my_page_path
+  end
+
   def after_update_path_for(resource)
     customers_my_page_path
   end

--- a/app/views/customer/homes/top.html.erb
+++ b/app/views/customer/homes/top.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <!-- メイン部分 -->
-    <div class="col-md-8">
+    <div class="col-md-9">
       <div class="toptitle mb-4">
         <h1>Welcom to NaganoCake !</h1>
       </div>
@@ -30,13 +30,11 @@
 
       <!-- 新着商品を4件表示 -->
       <% @product.each do |product| %>
-        <div class="mt-3" style="float: right;">
-          <div class="col-md-12">
-            <div class="card">
-              <%= attachment_image_tag product, :image, format: 'jpeg', fallback: "no_image.jpg", height:150 %>
-              <p class= "mt-3"><%= link_to product.name, product_path(product.id) %></p>
-              <p>￥<%= product.price %></p>
-            </div>
+        <div class="col-md-3 mt-3" style="float: right;">
+          <div class="card">
+            <%= attachment_image_tag product, :image, format: 'jpeg', fallback: "no_image.jpg", height:150 %>
+            <p class= "mt-3"><%= link_to product.name, product_path(product.id) %></p>
+            <p>￥<%= product.price %></p>
           </div>
         </div>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,13 @@
     </header>
     <div class="my-2" id="notice"><%= notice %></div>
     <div class="my-2" id="alert"><%= alert %></div>
-    <%= yield %>
+
+    <div class="wrapper">
+      <%= yield %>
+      <div class="push"></div>
+    </div>
+
+    <footer>@NaganoCake. @Nature-field</footer>
+
   </body>
 </html>


### PR DESCRIPTION
フッター追加しまた。間違った点有ればご指摘頂ければ幸いです。
背景色ですが、コンテンツ量が少ない時はフッターが真ん中に来るので、
見栄え的にあまり良くないかと思い無しとしてあります。

先に上げていた＃100番のプルリクエストと編集内容被っているので、
＃100は取り下げました。

-----------------------------------------------------------------
＃100

トップ画面の新着商品４件を表示する記述で、ブートストラップの記述に誤りが
有りましたので修正しました。
・商品の画像幅によって、レイアウトが崩れてしまう点を修正

会員側で新規会員登録した際に、マイページではなくトップページに
遷移していたので修正しました。